### PR TITLE
Enable adding sub-directory sources of a zarr-file

### DIFF
--- a/mobie/metadata/source_metadata.py
+++ b/mobie/metadata/source_metadata.py
@@ -183,6 +183,7 @@ def add_source_to_dataset(
     source_type,
     source_name,
     image_metadata_path,
+    file_format=None,
     view=None,
     table_folder=None,
     overwrite=True,
@@ -218,6 +219,7 @@ def add_source_to_dataset(
 
     if source_type == "image":
         source_metadata = get_image_metadata(dataset_folder, image_metadata_path,
+                                             file_format=file_format,
                                              description=description)
     else:
         source_metadata = get_segmentation_metadata(dataset_folder,

--- a/mobie/validation/metadata.py
+++ b/mobie/validation/metadata.py
@@ -106,7 +106,7 @@ def _check_data(storage, format_, name, dataset_folder,
         path = os.path.join(dataset_folder, storage["relativePath"])
         assert_true(os.path.exists(path), f"Could not find data for {name} at {path}")
 
-        with open_file(path, "r") as f:
+        with open_file(path, "r", ext=".zarr") as f:
             ome_name = f.attrs["multiscales"][0]["name"]
         assert_equal(name, ome_name, f"Source name and name in ngff metadata don't match: {name} != {ome_name}")
 


### PR DESCRIPTION
This PR enables adding wells of an hcs-zarr file as sources to a dataset. To add a well is stored in a sub-dir of a `plate.ome.zarr` e.g. 
```
plate.ome.zarr
├── B                                            // Row
│   ├── 02                                     // Column
│   │   ├── 0                                  // First field of view 
│   │   │   ├── 0  
```
we would call:
```
add_source_to_dataset("/path/to/mobie/data/dataset", 
                                       "image", 
                                       "source-name", 
                                       image_metadata_path="/path/to/mobie/data/dataset/images/ome-zarr/plate_01.ome.zarr/B/02/0")
```
Since `.ome.zarr` is part of the file path it will not be inferred automatically. Adding the argument `file_format` fixes this issue.:
```
add_source_to_dataset("/path/to/mobie/data/dataset", 
                                       "image", 
                                       "source-name", 
                                       image_metadata_path="/path/to/mobie/data/dataset/images/ome-zarr/plate_01.ome.zarr/B/02/0",
                                       file_format="ome.zarr")
```

The second change ensures that `ome.zarr` files are opened with the `zarr` reader during validation.