### PR TITLE
Add more table functionality

### DIFF
--- a/mobie/metadata/source_metadata.py
+++ b/mobie/metadata/source_metadata.py
@@ -236,6 +236,7 @@ def add_source_to_dataset(
     overwrite=True,
     description=None,
     channel=None,
+    suppress_warnings=False,
     **kwargs,
 ):
     """ Add source metadata to a MoBIE dataset.
@@ -255,6 +256,7 @@ def add_source_to_dataset(
         description [str] - description for this source (default: None)
         channel [int] - the channel to load from the data.
             Currently only supported for the ome.zarr format (default: None)
+        suppress_warnings [bool] - a flag to suppress warnings raised by the metadata validation (default: False)
         kwargs - additional keyword arguments for spot source
     """
     dataset_metadata = read_dataset_metadata(dataset_folder)

--- a/mobie/tables/default_table.py
+++ b/mobie/tables/default_table.py
@@ -13,7 +13,7 @@ from .utils import remove_background_label_row, read_table
 from ..utils import write_global_config
 
 
-def check_and_copy_default_table(input_path, output_path, is_2d):
+def check_and_copy_default_table(input_path, output_path, is_2d, suppress_warnings=False):
     tab = read_table(input_path)
     required_column_names = {"label_id", "anchor_x", "anchor_y"}
     recommended_column_names = {"bb_min_x", "bb_min_y", "bb_max_x", "bb_max_y"}
@@ -24,7 +24,7 @@ def check_and_copy_default_table(input_path, output_path, is_2d):
     if missing_columns:
         raise ValueError(f"The table at {input_path} is missing the following required columns: {missing_columns}")
     missing_columns = list(recommended_column_names - set(tab.columns))
-    if missing_columns:
+    if missing_columns and not suppress_warnings:
         warnings.warn(f"The table at {input_path} is missing the following recommended columns: {missing_columns}")
     tab.to_csv(output_path, sep="\t", index=False, na_rep="nan")
 

--- a/mobie/tables/default_table.py
+++ b/mobie/tables/default_table.py
@@ -11,15 +11,12 @@ from elf.io import open_file
 from skimage.measure import regionprops
 from .utils import remove_background_label_row, read_table
 from ..utils import write_global_config
+from ..validation.tables import get_columns_for_table_format
 
 
 def check_and_copy_default_table(input_path, output_path, is_2d, suppress_warnings=False):
     tab = read_table(input_path)
-    required_column_names = {"label_id", "anchor_x", "anchor_y"}
-    recommended_column_names = {"bb_min_x", "bb_min_y", "bb_max_x", "bb_max_y"}
-    if not is_2d:
-        required_column_names = required_column_names.union({"anchor_z"})
-        recommended_column_names = recommended_column_names.union({"bb_min_z", "bb_max_z"})
+    required_column_names, recommended_column_names, _ = get_columns_for_table_format(tab, is_2d)
     missing_columns = list(required_column_names - set(tab.columns))
     if missing_columns:
         raise ValueError(f"The table at {input_path} is missing the following required columns: {missing_columns}")

--- a/mobie/validation/metadata.py
+++ b/mobie/validation/metadata.py
@@ -78,7 +78,7 @@ def validate_source_metadata(name, metadata,
                              dataset_folder=None, is_2d=None,
                              require_local_data=True, require_remote_data=False,
                              assert_true=_assert_true, assert_equal=_assert_equal,
-                             assert_in=_assert_in):
+                             assert_in=_assert_in, suppress_warnings=False):
     # static validation with json schema
     try:
         validate_with_schema(metadata, "source")
@@ -99,7 +99,8 @@ def validate_source_metadata(name, metadata,
             table_folder = os.path.join(dataset_folder, source_metadata["tableData"]["tsv"]["relativePath"])
             if source_type == "segmentation":
                 assert is_2d is not None
-                check_segmentation_tables(table_folder, is_2d, assert_true=assert_true)
+                check_segmentation_tables(table_folder, is_2d, assert_true=assert_true,
+                                          suppress_warnings=suppress_warnings)
             elif source_type == "regions":
                 check_region_tables(table_folder, assert_true=assert_true)
             elif source_type == "spots":

--- a/mobie/validation/tables.py
+++ b/mobie/validation/tables.py
@@ -75,13 +75,37 @@ def check_region_tables(table_folder, assert_true=_assert_true):
     _check_tables(table_folder, required_columns, merge_columns, assert_true=assert_true)
 
 
+def get_columns_for_table_format(tab, is_2d):
+    if tab.columns[0] == "label_id":  # the default MoBIE segmentation table format
+        required_column_names = {"label_id", "anchor_x", "anchor_y"}
+        recommended_column_names = {"bb_min_x", "bb_min_y", "bb_max_x", "bb_max_y"}
+        if not is_2d:
+            required_column_names = required_column_names.union({"anchor_z"})
+            recommended_column_names = recommended_column_names.union({"bb_min_z", "bb_max_z"})
+        merge_column_names = {"label_id", "timepoint"}
+    elif tab.columns[0] == "label":  # the skimage.regionprops format
+        required_column_names = {"label", "centroid-0", "centroid-1"}
+        if is_2d:
+            recommended_column_names = {f"bbox-{i}" for i in range(4)}
+        else:
+            required_column_names = required_column_names.union({"centroid-2"})
+            recommended_column_names = {f"bbox-{i}" for i in range(6)}
+        merge_column_names = {"label", "frame"}
+    else:
+        raise ValueError(f"The segmentation table with columns {tab.columns} did not match any known table format.")
+    return required_column_names, recommended_column_names, merge_column_names
+
+
+def _parse_segmentation_table(table_folder, is_2d, assert_true):
+    default_table_path = os.path.join(table_folder, "default.tsv")
+    assert_true(os.path.exists(default_table_path), f"Default table {default_table_path} does not exist.")
+    tab = _read_table(default_table_path)
+    required_columns, recommended_columns, merge_columns = get_columns_for_table_format(tab, is_2d)
+    return list(required_columns), list(recommended_columns), list(merge_columns)
+
+
 def check_segmentation_tables(table_folder, is_2d, assert_true=_assert_true, suppress_warnings=False):
-    required_columns = ["label_id",  "anchor_x", "anchor_y"]
-    recommended_columns = ["bb_min_x", "bb_min_y", "bb_max_x", "bb_max_y"]
-    if not is_2d:
-        required_columns.extend(["anchor_z"])
-        recommended_columns.extend(["bb_min_z", "bb_max_z"])
-    merge_columns = ["label_id", "timepoint"]
+    required_columns, recommended_columns, merge_columns = _parse_segmentation_table(table_folder, is_2d, assert_true)
     _check_tables(
         table_folder, required_columns, merge_columns,
         assert_true=assert_true, recommended_columns=recommended_columns,

--- a/mobie/validation/tables.py
+++ b/mobie/validation/tables.py
@@ -19,7 +19,8 @@ def _read_table(table):
         raise ValueError(f"Invalid table format, expected either filepath or pandas DataFrame, got {type(table)}.")
 
 
-def _check_tables(table_folder, required_columns, merge_columns, assert_true, recommended_columns=[]):
+def _check_tables(table_folder, required_columns, merge_columns, assert_true,
+                  recommended_columns=[], suppress_warnings=False):
     # check that table folder and default table exist
     assert_true(os.path.isdir(table_folder), f"Table root folder {table_folder} does not exist.")
     default_table_path = os.path.join(table_folder, "default.tsv")
@@ -34,7 +35,7 @@ def _check_tables(table_folder, required_columns, merge_columns, assert_true, re
             f"Required column {col} is not present in the default table @ {default_table_path}."
         )
     for col in recommended_columns:
-        if col not in default_table.columns:
+        if col not in default_table.columns and not suppress_warnings:
             warnings.warn(f"Recommended column {col} is not present in the default table @ {default_table_path}.")
 
     # get all expected merge columns and their values
@@ -74,7 +75,7 @@ def check_region_tables(table_folder, assert_true=_assert_true):
     _check_tables(table_folder, required_columns, merge_columns, assert_true=assert_true)
 
 
-def check_segmentation_tables(table_folder, is_2d, assert_true=_assert_true):
+def check_segmentation_tables(table_folder, is_2d, assert_true=_assert_true, suppress_warnings=False):
     required_columns = ["label_id",  "anchor_x", "anchor_y"]
     recommended_columns = ["bb_min_x", "bb_min_y", "bb_max_x", "bb_max_y"]
     if not is_2d:
@@ -82,7 +83,9 @@ def check_segmentation_tables(table_folder, is_2d, assert_true=_assert_true):
         recommended_columns.extend(["bb_min_z", "bb_max_z"])
     merge_columns = ["label_id", "timepoint"]
     _check_tables(
-        table_folder, required_columns, merge_columns, assert_true=assert_true, recommended_columns=recommended_columns
+        table_folder, required_columns, merge_columns,
+        assert_true=assert_true, recommended_columns=recommended_columns,
+        suppress_warnings=suppress_warnings,
     )
 
 


### PR DESCRIPTION
- Flag to suppress the warning when adding tables without recommended columns
- Add support for more table types

For now this only adds the table format from skimage.regionprops, which is the only other one described fully in https://github.com/mobie/mobie-viewer-fiji/issues/935. But adding more table formats will now be very easy.