### PR TITLE
Fix keys in project metadata

### DIFF
--- a/mobie/metadata/project_metadata.py
+++ b/mobie/metadata/project_metadata.py
@@ -18,9 +18,9 @@ def create_project_metadata(root, description=None, references=None):
         "datasets": []
     }
     if description is not None:
-        metadata[description] = description
+        metadata["description"] = description
     if references is not None:
-        metadata[references] = references
+        metadata["references"] = references
     write_project_metadata(root,  metadata)
 
 

--- a/test/metadata/test_project_metadata.py
+++ b/test/metadata/test_project_metadata.py
@@ -1,8 +1,10 @@
 import json
 import unittest
+import tempfile
 
 from jsonschema import ValidationError
 from mobie import SPEC_VERSION
+from mobie.metadata import create_project_metadata, read_project_metadata, add_dataset
 from mobie.validation.utils import validate_with_schema
 
 
@@ -59,6 +61,22 @@ class TestProjectMetadata(unittest.TestCase):
         metadata["specVersion"] = invalid_version
         with self.assertRaises(ValidationError):
             validate_with_schema(metadata, "project")
+
+    def test_create_project_metadata(self):
+        description = "Test project"
+        schema = self.get_schema()
+        with tempfile.TemporaryDirectory() as tempdir:
+            create_project_metadata(
+                root=tempdir,
+                description=description,
+            )
+            add_dataset(
+                root=tempdir,
+                dataset_name="alpha",
+                is_default=True,
+            )
+            metadata = read_project_metadata(tempdir)
+            validate_with_schema(metadata, schema)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The **keys** for `description` and `references` were taken from the provided **values**.

This commit adds a test for `create_project_metadata` that validates the metadata written to the file system.
